### PR TITLE
Use custom Required attribute to avoid collisions and aliases

### DIFF
--- a/TerraformPluginDotNet.Test/TestResource.cs
+++ b/TerraformPluginDotNet.Test/TestResource.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using MessagePack;
 using TerraformPluginDotNet.Resources;
 using TerraformPluginDotNet.Serialization;
-using KeyAttribute = MessagePack.KeyAttribute;
 
 namespace TerraformPluginDotNet.Test;
 

--- a/TerraformPluginDotNet/Resources/RequiredAttribute.cs
+++ b/TerraformPluginDotNet/Resources/RequiredAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace TerraformPluginDotNet.Resources;
+
+/// <summary>
+/// Indicates that a value is required.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class RequiredAttribute : Attribute
+{
+}

--- a/TerraformPluginDotNet/Schemas/SchemaBuilder.cs
+++ b/TerraformPluginDotNet/Schemas/SchemaBuilder.cs
@@ -1,6 +1,4 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Reflection;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;

--- a/samples/SampleProvider/SampleProvider/SampleFileResource.cs
+++ b/samples/SampleProvider/SampleProvider/SampleFileResource.cs
@@ -1,9 +1,7 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using MessagePack;
 using TerraformPluginDotNet.Resources;
 using TerraformPluginDotNet.Serialization;
-using Key = MessagePack.KeyAttribute;
 
 namespace SampleProvider;
 

--- a/samples/SchemaUpgrade/SchemaUpgrade/UpgradableResourceV2.cs
+++ b/samples/SchemaUpgrade/SchemaUpgrade/UpgradableResourceV2.cs
@@ -1,9 +1,7 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using MessagePack;
 using TerraformPluginDotNet.Resources;
 using TerraformPluginDotNet.Serialization;
-using Key = MessagePack.KeyAttribute;
 
 namespace SchemaUpgrade;
 


### PR DESCRIPTION
I really like this library as it helps me create a .NET terraform plugin very easily. Especially the `TerraformTestHost` is very nice, great work.

I've noticed that I run into namespace conflicts in resource specifications quite easily, as attributes from `MessagePack`, `System.ComponentModel` and `TerraformPluginDotNet.Resources` are used.

This PR fixes that issue by ditching the dependency on `System.ComponentModel` and implements `Required` attribute in `TerraformPluginDotNet.Resources`. The attribute from `System.ComponentModel` also has a `AllowEmptyStrings` property that is unused, so that is also dropped by this PR.