### PR TITLE
Split configuring provider and terraform to make testing more easy

### DIFF
--- a/samples/SampleProvider/SampleProvider.Test/SampleProviderTest.cs
+++ b/samples/SampleProvider/SampleProvider.Test/SampleProviderTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -145,19 +145,11 @@ content = ""Something to import.""
     [Test]
     public async Task TestConfigureFileHeader()
     {
-        using var terraform = await _host.CreateTerraformTestInstanceAsync(ProviderName, configure: false);
+        using var terraform = await _host.CreateTerraformTestInstanceAsync(ProviderName, configureProvider: false);
 
-        await File.WriteAllTextAsync(terraform.WorkDir + "/conf.tf", $@"
+        await File.AppendAllTextAsync(terraform.WorkDir + "/conf.tf", $@"
 provider ""{ProviderName}"" {{
   file_header = ""# File Header""
-}}
-terraform {{
-  required_providers {{
-    {ProviderName} = {{
-      source = ""example.com/example/{ProviderName}""
-      version = ""1.0.0""
-    }}
-  }}
 }}
 ");
 


### PR DESCRIPTION
If `configure` is set to `false` in `TerraformTestHost.CreateTerraformTestInstanceAsync`, the `terraform` section from `tf.conf` is also dropped.

This PR allows developers to choose what section they want to drop from `tf.conf`, so the somewhat magical `example.com/example/{ProviderName}` provider config remains (in most of the cases) in `TerraformTestHost`. The test host also depends on `example.com/example/{ProviderName}`, so it is better to keep it as contained as possible.