### PR TITLE
Enable nullable so interface helps display whether certain objects are null

### DIFF
--- a/TerraformPluginDotNet/CertificateGenerator.cs
+++ b/TerraformPluginDotNet/CertificateGenerator.cs
@@ -69,7 +69,7 @@ public static class CertificateGenerator
         // Sign certificate
         var signatureFactory = new Asn1SignatureFactory("SHA256WithRSA", issuerPrivKey, random);
         var certificate = certificateGenerator.Generate(signatureFactory);
-        var x509 = new X509Certificate2(certificate.GetEncoded(), (string)null, X509KeyStorageFlags.Exportable);
+        var x509 = new X509Certificate2(certificate.GetEncoded(), (string?)null, X509KeyStorageFlags.Exportable);
 
         // Private key
         var privateKeyInfo = PrivateKeyInfoFactory.CreatePrivateKeyInfo(subjectKeyPair.Private);

--- a/TerraformPluginDotNet/HostApplicationLifetimeExtensions.cs
+++ b/TerraformPluginDotNet/HostApplicationLifetimeExtensions.cs
@@ -12,7 +12,7 @@ public static class HostApplicationLifetimeExtensions
     {
         lifetime.ApplicationStarted.Register(() =>
         {
-            var serverAddress = app.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First();
+            var serverAddress = app.ServerFeatures.Get<IServerAddressesFeature>()?.Addresses.First() ?? throw new InvalidOperationException($"{nameof(IServerAddressesFeature)} not found in {nameof(app.ServerFeatures)}");
             var serverUri = new Uri(serverAddress);
             var host = serverUri.Host == "localhost" ? "127.0.0.1" : serverUri.Host;
 

--- a/TerraformPluginDotNet/PluginHostCertificate.cs
+++ b/TerraformPluginDotNet/PluginHostCertificate.cs
@@ -2,7 +2,4 @@
 
 namespace TerraformPluginDotNet;
 
-public record PluginHostCertificate
-{
-    public X509Certificate2 Certificate { get; init; }
-}
+public record PluginHostCertificate(X509Certificate2 Certificate);

--- a/TerraformPluginDotNet/ProviderConfig/ProviderConfigurationRegistry.cs
+++ b/TerraformPluginDotNet/ProviderConfig/ProviderConfigurationRegistry.cs
@@ -2,9 +2,6 @@
 
 namespace TerraformPluginDotNet.ProviderConfig;
 
-record ProviderConfigurationRegistry
-{
-    public Schema ConfigurationSchema { get; init; }
-
-    public Type ConfigurationType { get; init; }
-}
+record ProviderConfigurationRegistry(
+    Schema ConfigurationSchema,
+    Type ConfigurationType);

--- a/TerraformPluginDotNet/ResourceProvider/DefaultResourceUpgrader.cs
+++ b/TerraformPluginDotNet/ResourceProvider/DefaultResourceUpgrader.cs
@@ -17,6 +17,6 @@ class DefaultResourceUpgrader<T> : IResourceUpgrader<T>
 
     public Task<T> UpgradeResourceStateAsync(long schemaVersion, ReadOnlyMemory<byte> json)
     {
-        return Task.FromResult(_serializer.DeserializeJson<T>(json));
+        return Task.FromResult(_serializer.DeserializeJson<T>(json) ?? throw new InvalidOperationException("Invalid Json provided"));
     }
 }

--- a/TerraformPluginDotNet/ResourceProvider/IResourceProvider.cs
+++ b/TerraformPluginDotNet/ResourceProvider/IResourceProvider.cs
@@ -2,13 +2,13 @@
 
 public interface IResourceProvider<T>
 {
-    Task<T> PlanAsync(T prior, T proposed);
+    Task<T> PlanAsync(T? prior, T proposed);
 
     Task<T> CreateAsync(T planned);
 
     Task<T> ReadAsync(T resource);
 
-    Task<T> UpdateAsync(T prior, T planned);
+    Task<T> UpdateAsync(T? prior, T planned);
 
     Task DeleteAsync(T resource);
 

--- a/TerraformPluginDotNet/Schemas/SchemaBuilder.cs
+++ b/TerraformPluginDotNet/Schemas/SchemaBuilder.cs
@@ -4,6 +4,7 @@ using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using TerraformPluginDotNet.Resources;
 using Tfplugin5;
+using KeyAttribute = MessagePack.KeyAttribute;
 
 namespace TerraformPluginDotNet.Schemas;
 
@@ -29,16 +30,29 @@ class SchemaBuilder : ISchemaBuilder
         var block = new Schema.Types.Block();
         foreach (var property in properties)
         {
-            var key = property.GetCustomAttribute<MessagePack.KeyAttribute>();
+            var key = property.GetCustomAttribute<KeyAttribute>();
+            if (key == null)
+            {
+                _logger.LogWarning($"{nameof(KeyAttribute)} attribute required for property {property.Name} in {type.Name}");
+                continue;
+            }
+
             var description = property.GetCustomAttribute<DescriptionAttribute>();
             var required = IsRequiredAttribute(property);
             var computed = property.GetCustomAttribute<ComputedAttribute>() != null;
 
+            var terraformType = GetTerraformType(property.PropertyType);
+            if (terraformType == null)
+            {
+                _logger.LogWarning($"Unable to convert the type {property.PropertyType.FullName} of property {property.Name} in {type.Name} to Terraform type.");
+                continue;
+            }
+
             block.Attributes.Add(new Schema.Types.Attribute
             {
                 Name = key.StringKey,
-                Type = ByteString.CopyFromUtf8(GetTerraformType(property.PropertyType)),
-                Description = description.Description,
+                Type = ByteString.CopyFromUtf8(terraformType),
+                Description = description?.Description,
                 Optional = !required,
                 Required = required,
                 Computed = computed,
@@ -58,11 +72,11 @@ class SchemaBuilder : ISchemaBuilder
             (property.PropertyType.IsValueType && Nullable.GetUnderlyingType(property.PropertyType) == null);
     }
 
-    private static string GetTerraformType(Type t)
+    private static string? GetTerraformType(Type t)
     {
-        if (t.IsValueType && Nullable.GetUnderlyingType(t) != null)
+        if (t.IsValueType && Nullable.GetUnderlyingType(t) is Type underlyingType)
         {
-            t = Nullable.GetUnderlyingType(t);
+            t = underlyingType;
         }
 
         if (t == typeof(string))
@@ -98,6 +112,6 @@ class SchemaBuilder : ISchemaBuilder
             return $"[\"list\",{elementType}]";
         }
 
-        throw new NotSupportedException($"Unable to convert {t.FullName} to Terraform type.");
+        return null;
     }
 }

--- a/TerraformPluginDotNet/Serialization/ComputedStringValueFormatter.cs
+++ b/TerraformPluginDotNet/Serialization/ComputedStringValueFormatter.cs
@@ -4,9 +4,9 @@ using MessagePack.Formatters;
 
 namespace TerraformPluginDotNet.Serialization;
 
-public class ComputedStringValueFormatter : IMessagePackFormatter<string>
+public class ComputedStringValueFormatter : IMessagePackFormatter<string?>
 {
-    public string Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    public string? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
     {
         if (reader.TryReadNil())
         {
@@ -21,7 +21,7 @@ public class ComputedStringValueFormatter : IMessagePackFormatter<string>
         return reader.ReadString();
     }
 
-    public void Serialize(ref MessagePackWriter writer, string value, MessagePackSerializerOptions options)
+    public void Serialize(ref MessagePackWriter writer, string? value, MessagePackSerializerOptions options)
     {
         if (value == null)
         {

--- a/TerraformPluginDotNet/Serialization/DefaultDynamicValueSerializer.cs
+++ b/TerraformPluginDotNet/Serialization/DefaultDynamicValueSerializer.cs
@@ -7,7 +7,8 @@ public class DefaultDynamicValueSerializer : IDynamicValueSerializer
 {
     public T DeserializeJson<T>(ReadOnlyMemory<byte> value)
     {
-        return JsonSerializer.Deserialize<T>(value.Span, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        return JsonSerializer.Deserialize<T>(value.Span, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+             ?? throw new InvalidOperationException("Invalid Json provided");
     }
 
     public T DeserializeMsgPack<T>(ReadOnlyMemory<byte> value)

--- a/TerraformPluginDotNet/ServiceCollectionExtensions.cs
+++ b/TerraformPluginDotNet/ServiceCollectionExtensions.cs
@@ -37,11 +37,9 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddTerraformProviderConfigurator<TConfig, TProviderConfigurator>(this IServiceCollection services)
         where TProviderConfigurator : IProviderConfigurator<TConfig>
     {
-        services.AddSingleton(s => new ProviderConfigurationRegistry
-        {
-            ConfigurationSchema = s.GetRequiredService<ISchemaBuilder>().BuildSchema(typeof(TConfig)),
-            ConfigurationType = typeof(TConfig),
-        });
+        services.AddSingleton(s => new ProviderConfigurationRegistry(
+            ConfigurationSchema: s.GetRequiredService<ISchemaBuilder>().BuildSchema(typeof(TConfig)),
+            ConfigurationType: typeof(TConfig)));
 
         services.AddTransient<IProviderConfigurator<TConfig>>(s => s.GetRequiredService<TProviderConfigurator>());
         return services;

--- a/TerraformPluginDotNet/Services/Terraform5ProviderService.cs
+++ b/TerraformPluginDotNet/Services/Terraform5ProviderService.cs
@@ -13,14 +13,14 @@ class Terraform5ProviderService : Provider.ProviderBase
     private readonly IHostApplicationLifetime _lifetime;
     private readonly ResourceRegistry _resourceRegistry;
     private readonly IServiceProvider _serviceProvider;
-    private readonly ProviderConfigurationRegistry _providerConfiguration;
+    private readonly ProviderConfigurationRegistry? _providerConfiguration;
 
     public Terraform5ProviderService(
         ILogger<Terraform5ProviderService> logger,
         IHostApplicationLifetime lifetime,
         ResourceRegistry resourceRegistry,
         IServiceProvider serviceProvider,
-        ProviderConfigurationRegistry providerConfiguration = null)
+        ProviderConfigurationRegistry? providerConfiguration = null)
     {
         _logger = logger;
         _lifetime = lifetime;
@@ -38,8 +38,8 @@ class Terraform5ProviderService : Provider.ProviderBase
 
         var configurationHostType = typeof(ProviderConfigurationHost<>).MakeGenericType(_providerConfiguration.ConfigurationType);
         var configurationHost = _serviceProvider.GetService(configurationHostType);
-        await (Task)configurationHostType.GetMethod(nameof(ProviderConfigurationHost<object>.ConfigureAsync))
-            .Invoke(configurationHost, new[] { request });
+        await (Task)configurationHostType.GetMethod(nameof(ProviderConfigurationHost<object>.ConfigureAsync))!
+            .Invoke(configurationHost, new[] { request })!;
         return new Configure.Types.Response { };
     }
 
@@ -71,8 +71,8 @@ class Terraform5ProviderService : Provider.ProviderBase
 
         var providerHostType = typeof(ResourceProviderHost<>).MakeGenericType(resourceType);
         var provider = _serviceProvider.GetService(providerHostType);
-        return (Task<PlanResourceChange.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.PlanResourceChange))
-            .Invoke(provider, new[] { request });
+        return (Task<PlanResourceChange.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.PlanResourceChange))!
+            .Invoke(provider, new[] { request })!;
     }
 
     public override Task<ApplyResourceChange.Types.Response> ApplyResourceChange(ApplyResourceChange.Types.Request request, ServerCallContext context)
@@ -90,8 +90,8 @@ class Terraform5ProviderService : Provider.ProviderBase
 
         var providerHostType = typeof(ResourceProviderHost<>).MakeGenericType(resourceType);
         var provider = _serviceProvider.GetService(providerHostType);
-        return (Task<ApplyResourceChange.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.ApplyResourceChange))
-            .Invoke(provider, new[] { request });
+        return (Task<ApplyResourceChange.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.ApplyResourceChange))!
+            .Invoke(provider, new[] { request })!;
     }
 
     public override Task<UpgradeResourceState.Types.Response> UpgradeResourceState(UpgradeResourceState.Types.Request request, ServerCallContext context)
@@ -109,8 +109,8 @@ class Terraform5ProviderService : Provider.ProviderBase
 
         var providerHostType = typeof(ResourceProviderHost<>).MakeGenericType(resourceType);
         var provider = _serviceProvider.GetService(providerHostType);
-        return (Task<UpgradeResourceState.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.UpgradeResourceState))
-            .Invoke(provider, new[] { request });
+        return (Task<UpgradeResourceState.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.UpgradeResourceState))!
+            .Invoke(provider, new[] { request })!;
     }
 
     public override Task<ReadResource.Types.Response> ReadResource(ReadResource.Types.Request request, ServerCallContext context)
@@ -128,8 +128,8 @@ class Terraform5ProviderService : Provider.ProviderBase
 
         var providerHostType = typeof(ResourceProviderHost<>).MakeGenericType(resourceType);
         var provider = _serviceProvider.GetService(providerHostType);
-        return (Task<ReadResource.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.ReadResource))
-            .Invoke(provider, new[] { request });
+        return (Task<ReadResource.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.ReadResource))!
+            .Invoke(provider, new[] { request })!;
     }
 
     public override Task<ImportResourceState.Types.Response> ImportResourceState(ImportResourceState.Types.Request request, ServerCallContext context)
@@ -147,8 +147,8 @@ class Terraform5ProviderService : Provider.ProviderBase
 
         var providerHostType = typeof(ResourceProviderHost<>).MakeGenericType(resourceType);
         var provider = _serviceProvider.GetService(providerHostType);
-        return (Task<ImportResourceState.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.ImportResourceState))
-            .Invoke(provider, new[] { request });
+        return (Task<ImportResourceState.Types.Response>)providerHostType.GetMethod(nameof(ResourceProviderHost<object>.ImportResourceState))!
+            .Invoke(provider, new[] { request })!;
     }
 
     public override Task<PrepareProviderConfig.Types.Response> PrepareProviderConfig(PrepareProviderConfig.Types.Request request, ServerCallContext context)

--- a/TerraformPluginDotNet/TerraformPluginDotNet.csproj
+++ b/TerraformPluginDotNet/TerraformPluginDotNet.csproj
@@ -9,6 +9,7 @@
     <Authors>SamuelFisher</Authors>
     <WarningsAsErrors>true</WarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Protobuf Include="Protos\tfplugin5.2.proto" GrpcServices="Server" />

--- a/TerraformPluginDotNet/TerraformPluginHost.cs
+++ b/TerraformPluginDotNet/TerraformPluginHost.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -52,10 +52,8 @@ public static class TerraformPluginHost
             {
                 services.Configure<TerraformPluginHostOptions>(host.Configuration);
                 services.Configure<TerraformPluginHostOptions>(x => x.FullProviderName = fullProviderName);
-                services.AddSingleton(new PluginHostCertificate
-                {
-                    Certificate = CertificateGenerator.GenerateSelfSignedCertificate("CN=127.0.0.1", "CN=root ca", CertificateGenerator.GeneratePrivateKey()),
-                });
+                services.AddSingleton(new PluginHostCertificate(
+                    Certificate: CertificateGenerator.GenerateSelfSignedCertificate("CN=127.0.0.1", "CN=root ca", CertificateGenerator.GeneratePrivateKey())));
             })
             .ConfigureWebHostDefaults(webBuilder =>
             {

--- a/TerraformPluginDotNet/TerraformPluginHostOptions.cs
+++ b/TerraformPluginDotNet/TerraformPluginHostOptions.cs
@@ -8,7 +8,7 @@ public class TerraformPluginHostOptions
     /// The full provider name. For example, `example.com/example/dotnetsample`.
     /// </summary>
     [Required]
-    public string FullProviderName { get; set; }
+    public string FullProviderName { get; set; } = null!;
 
     /// <summary>
     /// Configures debug mode which listens on H2C instead of TLS.

--- a/samples/SampleProvider/SampleProvider/Configuration.cs
+++ b/samples/SampleProvider/SampleProvider/Configuration.cs
@@ -8,5 +8,5 @@ public class Configuration
 {
     [Key("file_header")]
     [Description("Header text to prepend to every file.")]
-    public string FileHeader { get; set; }
+    public string? FileHeader { get; set; }
 }

--- a/samples/SampleProvider/SampleProvider/SampleConfigurator.cs
+++ b/samples/SampleProvider/SampleProvider/SampleConfigurator.cs
@@ -5,7 +5,7 @@ namespace SampleProvider;
 
 public class SampleConfigurator : IProviderConfigurator<Configuration>
 {
-    public Configuration Config { get; private set; }
+    public Configuration? Config { get; private set; }
 
     public Task ConfigureAsync(Configuration config)
     {

--- a/samples/SampleProvider/SampleProvider/SampleFileResource.cs
+++ b/samples/SampleProvider/SampleProvider/SampleFileResource.cs
@@ -13,15 +13,15 @@ public class SampleFileResource
     [Computed]
     [Description("Unique ID for this resource.")]
     [MessagePackFormatter(typeof(ComputedStringValueFormatter))]
-    public string Id { get; set; }
+    public string? Id { get; set; }
 
     [Key("path")]
     [Description("Path to the file.")]
     [Required]
-    public string Path { get; set; }
+    public string Path { get; set; } = null!;
 
     [Key("content")]
     [Description("Contents of the file.")]
     [Required]
-    public string Content { get; set; }
+    public string Content { get; set; } = null!;
 }

--- a/samples/SampleProvider/SampleProvider/SampleFileResourceProvider.cs
+++ b/samples/SampleProvider/SampleProvider/SampleFileResourceProvider.cs
@@ -16,7 +16,7 @@ public class SampleFileResourceProvider : IResourceProvider<SampleFileResource>
         _configurator = configurator;
     }
 
-    public Task<SampleFileResource> PlanAsync(SampleFileResource prior, SampleFileResource proposed)
+    public Task<SampleFileResource> PlanAsync(SampleFileResource? prior, SampleFileResource proposed)
     {
         return Task.FromResult(proposed);
     }
@@ -41,7 +41,7 @@ public class SampleFileResourceProvider : IResourceProvider<SampleFileResource>
         return resource;
     }
 
-    public async Task<SampleFileResource> UpdateAsync(SampleFileResource prior, SampleFileResource planned)
+    public async Task<SampleFileResource> UpdateAsync(SampleFileResource? prior, SampleFileResource planned)
     {
         await File.WriteAllTextAsync(planned.Path, BuildContent(planned.Content));
         return planned;

--- a/samples/SampleProvider/SampleProvider/SampleProvider.csproj
+++ b/samples/SampleProvider/SampleProvider/SampleProvider.csproj
@@ -6,6 +6,7 @@
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
     <AssemblyName>terraform-provider-$([System.String]::Copy($(MSBuildProjectName)).ToLowerInvariant())</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TerraformPluginDotNet\TerraformPluginDotNet.csproj" />

--- a/samples/SchemaUpgrade/SchemaUpgrade/PreviousVersions/UpgradableResourceV1.cs
+++ b/samples/SchemaUpgrade/SchemaUpgrade/PreviousVersions/UpgradableResourceV1.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using TerraformPluginDotNet.Resources;
+﻿using TerraformPluginDotNet.Resources;
 
 namespace SchemaUpgrade.PreviousVersions;
 
@@ -9,8 +8,8 @@ namespace SchemaUpgrade.PreviousVersions;
 [SchemaVersion(1)]
 internal class UpgradableResourceV1
 {
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     // Renamed to `Data` in V2.
-    public string Value { get; set; }
+    public string Value { get; set; } = null!;
 }

--- a/samples/SchemaUpgrade/SchemaUpgrade/SchemaUpgrade.csproj
+++ b/samples/SchemaUpgrade/SchemaUpgrade/SchemaUpgrade.csproj
@@ -5,6 +5,7 @@
     <PublishSingleFile>true</PublishSingleFile>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TerraformPluginDotNet\TerraformPluginDotNet.csproj" />

--- a/samples/SchemaUpgrade/SchemaUpgrade/UpgradableResourceProvider.cs
+++ b/samples/SchemaUpgrade/SchemaUpgrade/UpgradableResourceProvider.cs
@@ -7,7 +7,7 @@ namespace SchemaUpgrade;
 
 public class UpgradableResourceProvider : IResourceProvider<UpgradableResourceV2>
 {
-    public Task<UpgradableResourceV2> PlanAsync(UpgradableResourceV2 prior, UpgradableResourceV2 proposed)
+    public Task<UpgradableResourceV2> PlanAsync(UpgradableResourceV2? prior, UpgradableResourceV2 proposed)
     {
         return Task.FromResult(proposed);
     }
@@ -32,7 +32,7 @@ public class UpgradableResourceProvider : IResourceProvider<UpgradableResourceV2
         return Task.FromResult(resource);
     }
 
-    public Task<UpgradableResourceV2> UpdateAsync(UpgradableResourceV2 prior, UpgradableResourceV2 planned)
+    public Task<UpgradableResourceV2> UpdateAsync(UpgradableResourceV2? prior, UpgradableResourceV2 planned)
     {
         // Do nothing
         return Task.FromResult(planned);

--- a/samples/SchemaUpgrade/SchemaUpgrade/UpgradableResourceV2.cs
+++ b/samples/SchemaUpgrade/SchemaUpgrade/UpgradableResourceV2.cs
@@ -16,11 +16,11 @@ public class UpgradableResourceV2
     [Computed]
     [Description("Unique ID for this resource.")]
     [MessagePackFormatter(typeof(ComputedStringValueFormatter))]
-    public string Id { get; set; }
+    public string? Id { get; set; }
 
     // Renamed from `Value` in V1.
     [Key("data")]
     [Description("Some data.")]
     [Required]
-    public string Data { get; set; }
+    public string Data { get; set; } = null!;
 }


### PR DESCRIPTION
When implementing an `IResourceProvider` it helps when you know when to expect a `null` from terraform.

I've enabled nullable so I'm able to annotate `IResourceProvider<T>` and `IProviderConfigurator<T>`, but that also allowed me to correctly handle all the potential `null`s in the entire solution. In some situations where `null` is unlikely (like the reflection stuff) I've fixed it by adding `!` everywhere.