### PR TITLE
DataSource support added

### DIFF
--- a/TerraformPluginDotNet.Testing/Json/TerraformJson.cs
+++ b/TerraformPluginDotNet.Testing/Json/TerraformJson.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Immutable;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace TerraformPluginDotNet.Testing.Json;
@@ -16,6 +15,9 @@ public record TerraformJsonPlan
 
     [JsonPropertyName("resource_changes")]
     public ImmutableList<TerraformJsonResourceChange> ResourceChanges { get; init; }
+
+    [JsonPropertyName("prior_state")]
+    public PriorState PriorState { get; init; }
 }
 
 public record TerraformJsonResourceChange
@@ -62,4 +64,55 @@ public record TerraformJsonChange
 
     [JsonPropertyName("after")]
     public JsonElement After { get; init; }
+}
+
+public record PriorState
+{
+    [JsonPropertyName("format_version")]
+    public string FormatVersion { get; init; }
+
+    [JsonPropertyName("terraform_version")]
+    public string TerraformVersion { get; init; }
+
+    [JsonPropertyName("values")]
+    public StateValues Values { get; init; }
+}
+
+public class StateValues
+{
+    [JsonPropertyName("root_module")]
+    public Module RootModule { get; init; }
+}
+
+public class Module
+{
+    [JsonPropertyName("resources")]
+    public ImmutableList<Resource> Resources { get; init; }
+}
+
+public class Resource
+{
+    [JsonPropertyName("address")]
+    public string Address { get; init; }
+
+    [JsonPropertyName("mode")]
+    public string Mode { get; init; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; }
+
+    [JsonPropertyName("provider_name")]
+    public string ProviderName { get; init; }
+
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion { get; init; }
+
+    [JsonPropertyName("values")]
+    public JsonElement Values { get; init; }
+
+    [JsonPropertyName("sensitive_values")]
+    public JsonElement SensitiveValues { get; init; }
 }

--- a/TerraformPluginDotNet.sln
+++ b/TerraformPluginDotNet.sln
@@ -24,6 +24,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SchemaUpgrade", "samples\Sc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SchemaUpgrade.Test", "samples\SchemaUpgrade\SchemaUpgrade.Test\SchemaUpgrade.Test.csproj", "{7FF7611C-FB28-476E-B821-B0AC97DFA5F8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataSourceProvider", "samples\DataSourceProvider\DataSourceProvider\DataSourceProvider.csproj", "{98403831-CB6A-4B24-B829-7ACCB78F423A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataSourceProvider.Test", "samples\DataSourceProvider\DataSourceProvider.Test\DataSourceProvider.Test.csproj", "{ADBDFDA9-7C8F-467D-94A4-12DDDDCE82AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,6 +62,14 @@ Global
 		{7FF7611C-FB28-476E-B821-B0AC97DFA5F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7FF7611C-FB28-476E-B821-B0AC97DFA5F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7FF7611C-FB28-476E-B821-B0AC97DFA5F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98403831-CB6A-4B24-B829-7ACCB78F423A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98403831-CB6A-4B24-B829-7ACCB78F423A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98403831-CB6A-4B24-B829-7ACCB78F423A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98403831-CB6A-4B24-B829-7ACCB78F423A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADBDFDA9-7C8F-467D-94A4-12DDDDCE82AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADBDFDA9-7C8F-467D-94A4-12DDDDCE82AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADBDFDA9-7C8F-467D-94A4-12DDDDCE82AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADBDFDA9-7C8F-467D-94A4-12DDDDCE82AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -67,6 +79,8 @@ Global
 		{1A658183-230D-4CED-A410-A088ADA43945} = {50C52917-AE5D-4F53-BA93-092CB6D76025}
 		{0FC32FFB-42DA-493A-AEF3-69A82E743237} = {50C52917-AE5D-4F53-BA93-092CB6D76025}
 		{7FF7611C-FB28-476E-B821-B0AC97DFA5F8} = {50C52917-AE5D-4F53-BA93-092CB6D76025}
+		{98403831-CB6A-4B24-B829-7ACCB78F423A} = {50C52917-AE5D-4F53-BA93-092CB6D76025}
+		{ADBDFDA9-7C8F-467D-94A4-12DDDDCE82AA} = {50C52917-AE5D-4F53-BA93-092CB6D76025}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F7700C3-5F6B-4D22-A507-A2EA099D993D}

--- a/TerraformPluginDotNet/ResourceProvider/DataSourceProviderHost.cs
+++ b/TerraformPluginDotNet/ResourceProvider/DataSourceProviderHost.cs
@@ -1,0 +1,51 @@
+﻿using TerraformPluginDotNet.Serialization;
+using Tfplugin5;
+
+namespace TerraformPluginDotNet.ResourceProvider;
+
+class DataSourceProviderHost<T>
+{
+    private readonly IDataSourceProvider<T> _dataSourceProvider;
+    private readonly IDynamicValueSerializer _serializer;
+
+    public DataSourceProviderHost(
+        IDataSourceProvider<T> dataSourceProvider,
+        IDynamicValueSerializer serializer)
+    {
+        _dataSourceProvider = dataSourceProvider;
+        _serializer = serializer;
+    }
+
+    public async Task<ReadDataSource.Types.Response> ReadDataSource(ReadDataSource.Types.Request request)
+    {
+        var current = DeserializeDynamicValue(request.Config);
+
+        var read = await _dataSourceProvider.ReadAsync(current);
+        var readSerialized = SerializeDynamicValue(read);
+
+        return new ReadDataSource.Types.Response
+        {
+            State = readSerialized,
+        };
+    }
+
+    private T DeserializeDynamicValue(DynamicValue value)
+    {
+        if (!value.Msgpack.IsEmpty)
+        {
+            return _serializer.DeserializeMsgPack<T>(value.Msgpack.Memory);
+        }
+
+        if (!value.Json.IsEmpty)
+        {
+            return _serializer.DeserializeJson<T>(value.Json.Memory);
+        }
+
+        throw new ArgumentException("Either MessagePack or Json must be non-empty.", nameof(value));
+    }
+
+    private DynamicValue SerializeDynamicValue(T value)
+    {
+        return new DynamicValue { Msgpack = Google.Protobuf.ByteString.CopyFrom(_serializer.SerializeMsgPack(value)) };
+    }
+}

--- a/TerraformPluginDotNet/ResourceProvider/DataSourceRegistryRegistration.cs
+++ b/TerraformPluginDotNet/ResourceProvider/DataSourceRegistryRegistration.cs
@@ -1,0 +1,3 @@
+﻿namespace TerraformPluginDotNet.ResourceProvider;
+
+record DataSourceRegistryRegistration(string ResourceName, Type Type);

--- a/TerraformPluginDotNet/ResourceProvider/IDataSourceProvider.cs
+++ b/TerraformPluginDotNet/ResourceProvider/IDataSourceProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace TerraformPluginDotNet.ResourceProvider;
+
+public interface IDataSourceProvider<T>
+{
+    Task<T> ReadAsync(T request);
+}

--- a/TerraformPluginDotNet/ResourceProvider/IResourceRegistryContext.cs
+++ b/TerraformPluginDotNet/ResourceProvider/IResourceRegistryContext.cs
@@ -3,4 +3,6 @@
 public interface IResourceRegistryContext
 {
     void RegisterResource<T>(string resourceName);
+
+    void RegisterDataSource<T>(string dataSourceName);
 }

--- a/TerraformPluginDotNet/ResourceProvider/ResourceRegistry.cs
+++ b/TerraformPluginDotNet/ResourceProvider/ResourceRegistry.cs
@@ -5,16 +5,26 @@ namespace TerraformPluginDotNet.ResourceProvider;
 
 class ResourceRegistry
 {
-    public ResourceRegistry(ISchemaBuilder schemaBulder, IEnumerable<ResourceRegistryRegistration> registrations)
+    public ResourceRegistry(
+        ISchemaBuilder schemaBulder,
+        IEnumerable<ResourceRegistryRegistration> resourceRegistrations,
+        IEnumerable<DataSourceRegistryRegistration> dataSourceRegistrations)
     {
-        foreach (var registration in registrations)
+        foreach (var registration in resourceRegistrations)
         {
             Schemas.Add(registration.ResourceName, schemaBulder.BuildSchema(registration.Type));
+            Types.Add(registration.ResourceName, registration.Type);
+        }
+        foreach (var registration in dataSourceRegistrations)
+        {
+            DataSchemas.Add(registration.ResourceName, schemaBulder.BuildSchema(registration.Type));
             Types.Add(registration.ResourceName, registration.Type);
         }
     }
 
     public Dictionary<string, Schema> Schemas { get; } = new Dictionary<string, Schema>();
+
+    public Dictionary<string, Schema> DataSchemas { get; } = new Dictionary<string, Schema>();
 
     public Dictionary<string, Type> Types { get; } = new Dictionary<string, Type>();
 }

--- a/TerraformPluginDotNet/ResourceProvider/ServiceCollectionResourceRegistryContext.cs
+++ b/TerraformPluginDotNet/ResourceProvider/ServiceCollectionResourceRegistryContext.cs
@@ -13,13 +13,25 @@ class ServiceCollectionResourceRegistryContext : IResourceRegistryContext
 
     public void RegisterResource<T>(string resourceName)
     {
+        EnsureValidType<T>();
+
+        _services.AddSingleton(new ResourceRegistryRegistration(resourceName, typeof(T)));
+    }
+
+    public void RegisterDataSource<T>(string resourceName)
+    {
+        EnsureValidType<T>();
+
+        _services.AddSingleton(new DataSourceRegistryRegistration(resourceName, typeof(T)));
+    }
+
+    private static void EnsureValidType<T>()
+    {
         // Validation
         if (!typeof(T).IsPublic)
         {
             // Must be public to allow messagepack serialization.
             throw new InvalidOperationException($"Type {typeof(T).FullName} must be public in order to be used as a Terraform resource.");
         }
-
-        _services.AddSingleton(new ResourceRegistryRegistration(resourceName, typeof(T)));
     }
 }

--- a/TerraformPluginDotNet/ServiceCollectionExtensions.cs
+++ b/TerraformPluginDotNet/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<ISchemaBuilder, SchemaBuilder>();
         services.AddTransient(typeof(ProviderConfigurationHost<>));
         services.AddTransient(typeof(ResourceProviderHost<>));
+        services.AddTransient(typeof(DataSourceProviderHost<>));
         services.AddTransient(typeof(IResourceUpgrader<>), typeof(DefaultResourceUpgrader<>));
         services.AddTransient<IDynamicValueSerializer, DefaultDynamicValueSerializer>();
         return services;

--- a/TerraformPluginDotNet/Services/Terraform5ProviderService.cs
+++ b/TerraformPluginDotNet/Services/Terraform5ProviderService.cs
@@ -45,12 +45,19 @@ class Terraform5ProviderService : Provider.ProviderBase
 
     public override Task<GetProviderSchema.Types.Response> GetSchema(GetProviderSchema.Types.Request request, ServerCallContext context)
     {
-        var res = new GetProviderSchema.Types.Response();
-        res.Provider = _providerConfiguration?.ConfigurationSchema ?? new Schema { Block = new Schema.Types.Block { } };
+        var res = new GetProviderSchema.Types.Response
+        {
+            Provider = _providerConfiguration?.ConfigurationSchema ?? new Schema { Block = new Schema.Types.Block { } },
+        };
 
         foreach (var schema in _resourceRegistry.Schemas)
         {
             res.ResourceSchemas.Add(schema.Key, schema.Value);
+        }
+
+        foreach (var schema in _resourceRegistry.DataSchemas)
+        {
+            res.DataSourceSchemas.Add(schema.Key, schema.Value);
         }
 
         return Task.FromResult(res);
@@ -64,7 +71,7 @@ class Terraform5ProviderService : Provider.ProviderBase
             {
                 Diagnostics =
                     {
-                        new Diagnostic { Detail = "Unkonwn type name." },
+                        new Diagnostic { Detail = "Unknown type name." },
                     },
             });
         }
@@ -83,7 +90,7 @@ class Terraform5ProviderService : Provider.ProviderBase
             {
                 Diagnostics =
                     {
-                        new Diagnostic { Detail = "Unkonwn type name." },
+                        new Diagnostic { Detail = "Unknown type name." },
                     },
             });
         }
@@ -102,7 +109,7 @@ class Terraform5ProviderService : Provider.ProviderBase
             {
                 Diagnostics =
                     {
-                        new Diagnostic { Detail = "Unkonwn type name." },
+                        new Diagnostic { Detail = "Unknown type name." },
                     },
             });
         }
@@ -121,7 +128,7 @@ class Terraform5ProviderService : Provider.ProviderBase
             {
                 Diagnostics =
                     {
-                        new Diagnostic { Detail = "Unkonwn type name." },
+                        new Diagnostic { Detail = "Unknown type name." },
                     },
             });
         }
@@ -140,7 +147,7 @@ class Terraform5ProviderService : Provider.ProviderBase
             {
                 Diagnostics =
                     {
-                        new Diagnostic { Detail = "Unkonwn type name." },
+                        new Diagnostic { Detail = "Unknown type name." },
                     },
             });
         }
@@ -171,5 +178,24 @@ class Terraform5ProviderService : Provider.ProviderBase
     public override Task<ValidateResourceTypeConfig.Types.Response> ValidateResourceTypeConfig(ValidateResourceTypeConfig.Types.Request request, ServerCallContext context)
     {
         return Task.FromResult(new ValidateResourceTypeConfig.Types.Response());
+    }
+
+    public override Task<ReadDataSource.Types.Response> ReadDataSource(ReadDataSource.Types.Request request, ServerCallContext context)
+    {
+        if (!_resourceRegistry.Types.TryGetValue(request.TypeName, out var resourceType))
+        {
+            return Task.FromResult(new ReadDataSource.Types.Response
+            {
+                Diagnostics =
+                    {
+                        new Diagnostic { Detail = "Unknown type name." },
+                    },
+            });
+        }
+
+        var providerHostType = typeof(DataSourceProviderHost<>).MakeGenericType(resourceType);
+        var provider = _serviceProvider.GetService(providerHostType);
+        return (Task<ReadDataSource.Types.Response>)providerHostType.GetMethod(nameof(DataSourceProviderHost<object>.ReadDataSource))!
+            .Invoke(provider, new[] { request })!;
     }
 }

--- a/samples/DataSourceProvider/DataSourceProvider.Test/DataSourceProvider.Test.csproj
+++ b/samples/DataSourceProvider/DataSourceProvider.Test/DataSourceProvider.Test.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\TerraformPluginDotNet.Testing\TerraformPluginDotNet.Testing.csproj" />
+    <ProjectReference Include="..\DataSourceProvider\DataSourceProvider.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/DataSourceProvider/DataSourceProvider.Test/SampleProviderTest.cs
+++ b/samples/DataSourceProvider/DataSourceProvider.Test/SampleProviderTest.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using TerraformPluginDotNet;
+using TerraformPluginDotNet.ResourceProvider;
+using TerraformPluginDotNet.Testing;
+using static Tfplugin5.Provider;
+
+namespace DataSourceProvider.Test;
+
+[TestFixture(Category = "Functional", Explicit = true)]
+public class SampleProviderTest
+{
+    private const string ProviderName = "datasourceprovider";
+
+    private TerraformTestHost _host;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        _host = new TerraformTestHost(Environment.GetEnvironmentVariable("TF_PLUGIN_DOTNET_TEST_TF_BIN"));
+        _host.Start($"example.com/example/{ProviderName}", Configure);
+    }
+
+    [OneTimeTearDown]
+    public async Task TearDown()
+    {
+        await _host.DisposeAsync();
+    }
+
+    private void Configure(IServiceCollection services, IResourceRegistryContext registryContext)
+    {
+        services.AddSingleton<SampleConfigurator>();
+        services.AddTerraformProviderConfigurator<Configuration, SampleConfigurator>();
+        services.AddSingleton<IDataSourceProvider<SampleDataSource>, SampleDataSourceProvider>();
+        registryContext.RegisterDataSource<SampleDataSource>($"{ProviderName}_data");
+    }
+
+    [Test]
+    public async Task TestReadDataSource()
+    {
+        using var terraform = await _host.CreateTerraformTestInstanceAsync(ProviderName);
+
+        var resourcePath = Path.Combine(terraform.WorkDir, "file.tf");
+
+        await File.WriteAllTextAsync(resourcePath, $@"
+data ""{ProviderName}_data"" ""demo_data"" {{
+id = ""test""
+}}
+");
+
+        var output = await terraform.PlanWithOutputAsync();
+
+        Assert.That(output.PriorState.Values.RootModule.Resources[0].Values.GetProperty("data").GetString(), Is.EqualTo("No dummy data configured"));
+    }
+
+    [Test]
+    public async Task TestConfigureDataSource()
+    {
+        using var terraform = await _host.CreateTerraformTestInstanceAsync(ProviderName, configureProvider: false);
+
+        var resourcePath = Path.Combine(terraform.WorkDir, "file.tf");
+
+        await File.WriteAllTextAsync(resourcePath, $@"
+provider ""{ProviderName}"" {{
+    dummy_data = ""This is dummy data""
+}}
+
+data ""{ProviderName}_data"" ""demo_data"" {{
+id = ""test""
+}}
+
+");
+
+        var output = await terraform.PlanWithOutputAsync();
+
+        Assert.That(output.PriorState.Values.RootModule.Resources[0].Values.GetProperty("data").GetString(), Is.EqualTo("This is dummy data"));
+    }
+}

--- a/samples/DataSourceProvider/DataSourceProvider/Configuration.cs
+++ b/samples/DataSourceProvider/DataSourceProvider/Configuration.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel;
+using MessagePack;
+
+namespace DataSourceProvider;
+
+[MessagePackObject]
+public class Configuration
+{
+    [Key("dummy_data")]
+    [Description("Dummy data returned by the data source provider.")]
+    public string? Data { get; set; }
+}

--- a/samples/DataSourceProvider/DataSourceProvider/DataSourceProvider.csproj
+++ b/samples/DataSourceProvider/DataSourceProvider/DataSourceProvider.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <PublishSingleFile>true</PublishSingleFile>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>terraform-provider-$([System.String]::Copy($(MSBuildProjectName)).ToLowerInvariant())</AssemblyName>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\TerraformPluginDotNet\TerraformPluginDotNet.csproj" />
+  </ItemGroup>
+  <Target Name="PublishTerraformProvider" AfterTargets="Publish">
+    <PropertyGroup>
+      <TerraformTarget>unknown</TerraformTarget>
+      <TerraformTarget Condition="'$(RuntimeIdentifier)'=='win-x64'">windows_amd64</TerraformTarget>
+      <TerraformTarget Condition="'$(RuntimeIdentifier)'=='linux-x64'">linux_amd64</TerraformTarget>
+    </PropertyGroup>
+    <ZipDirectory
+      SourceDirectory="$(OutputPath)\publish\"
+      DestinationFile="$(OutputPath)\..\$(AssemblyName)_$(Version)_$(TerraformTarget).zip"
+      Overwrite="true" />
+  </Target>
+</Project>

--- a/samples/DataSourceProvider/DataSourceProvider/Program.cs
+++ b/samples/DataSourceProvider/DataSourceProvider/Program.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using TerraformPluginDotNet;
+using TerraformPluginDotNet.ResourceProvider;
+
+namespace DataSourceProvider;
+
+class Program
+{
+    static Task Main(string[] args)
+    {
+        // Use the default plugin host that takes care of certificates and hosting the Grpc services.
+
+        return TerraformPluginHost.RunAsync(args, "example.com/example/datasourceprovider", (services, registry) =>
+        {
+            services.AddSingleton<SampleConfigurator>();
+            services.AddTerraformProviderConfigurator<Configuration, SampleConfigurator>();
+            services.AddSingleton<IDataSourceProvider<SampleDataSource>, SampleDataSourceProvider>();
+            registry.RegisterDataSource<SampleDataSource>("datasourceprovider_data");
+        });
+    }
+}

--- a/samples/DataSourceProvider/DataSourceProvider/SampleConfigurator.cs
+++ b/samples/DataSourceProvider/DataSourceProvider/SampleConfigurator.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using TerraformPluginDotNet.ProviderConfig;
+
+namespace DataSourceProvider;
+
+public class SampleConfigurator : IProviderConfigurator<Configuration>
+{
+    public Configuration? Config { get; private set; }
+
+    public Task ConfigureAsync(Configuration config)
+    {
+        Config = config;
+        return Task.CompletedTask;
+    }
+}

--- a/samples/DataSourceProvider/DataSourceProvider/SampleDataSource.cs
+++ b/samples/DataSourceProvider/DataSourceProvider/SampleDataSource.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel;
+using MessagePack;
+using TerraformPluginDotNet.Resources;
+using TerraformPluginDotNet.Serialization;
+
+namespace DataSourceProvider;
+
+[SchemaVersion(1)]
+[MessagePackObject]
+public class SampleDataSource
+{
+    [Key("id")]
+    [Description("Id")]
+    [Required]
+    [MessagePackFormatter(typeof(ComputedStringValueFormatter))]
+    public string? Id { get; set; }
+
+    [Key("data")]
+    [Description("Dummy data.")]
+    [MessagePackFormatter(typeof(ComputedStringValueFormatter))]
+    public string? Data { get; set; }
+}

--- a/samples/DataSourceProvider/DataSourceProvider/SampleDataSourceProvider.cs
+++ b/samples/DataSourceProvider/DataSourceProvider/SampleDataSourceProvider.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using TerraformPluginDotNet.ResourceProvider;
+
+namespace DataSourceProvider;
+
+public class SampleDataSourceProvider : IDataSourceProvider<SampleDataSource>
+{
+    private readonly SampleConfigurator _configurator;
+
+    public SampleDataSourceProvider(SampleConfigurator configurator)
+    {
+        _configurator = configurator;
+    }
+
+    public Task<SampleDataSource> ReadAsync(SampleDataSource request)
+    {
+        return Task.FromResult(new SampleDataSource
+        {
+            Id = request.Id,
+            Data = _configurator.Config?.Data ?? "No dummy data configured",
+        });
+    }
+}

--- a/samples/DataSourceProvider/README.md
+++ b/samples/DataSourceProvider/README.md
@@ -1,0 +1,12 @@
+DataSourceProvider
+==============
+
+Basic example of a custom data source provider.
+
+This provider defines a new resource type that provides some dummy data.
+
+```hcl
+data "datasourceprovider_data" "demo_data" {
+  id = "test"
+}
+```


### PR DESCRIPTION
This PR adds support for building custom data sources in terraform, which can be used like this:

```
data "example_data" ""example"" {
  id = ""test""
}
```

The associated data source provider gets a request with a resource containing `id = "test"` and that provider can enrich the resource with data from external systems. 

I think this feature is quite useful because it allows for creating simple custom terraform provider that add a little bit of data that is missing from other providers. Data sources do not have any real state in terraform and can be viewed as a nice wrapper around an API call. 

(This PR is implemented using nullable enabled so it got some of those annotations)