### PR TITLE
Fixed a bug that led to random errors when the base64 encoded had '='…

### DIFF
--- a/TerraformPluginDotNet/HostApplicationLifetimeExtensions.cs
+++ b/TerraformPluginDotNet/HostApplicationLifetimeExtensions.cs
@@ -24,7 +24,10 @@ public static class HostApplicationLifetimeExtensions
             else
             {
                 var pluginHostCertificate = app.ApplicationServices.GetRequiredService<PluginHostCertificate>();
-                Console.WriteLine($"1|5|tcp|{host}:{serverUri.Port}|grpc|{Convert.ToBase64String(pluginHostCertificate.Certificate.RawData)}");
+
+                // Terraform seems not to like Base64 padding, so we trim
+                var base64EncodedCertificate = Convert.ToBase64String(pluginHostCertificate.Certificate.RawData).TrimEnd('=');
+                Console.WriteLine($"1|5|tcp|{host}:{serverUri.Port}|grpc|{base64EncodedCertificate}");
             }
         });
 


### PR DESCRIPTION
…, that represents the padding, but Terraform/Golang does not seem to like it.

As I am heavily working on my project , I just wanted to tell you, that trailing '=' characters lead Terraform to throw an exception, telling, that it cannot parse the Base64-encoded certificate.