### PR TITLE
Allow custom schemas using IDataSourceSchemaProvider

### DIFF
--- a/TerraformPluginDotNet/ResourceProvider/DataSourceRegistration.cs
+++ b/TerraformPluginDotNet/ResourceProvider/DataSourceRegistration.cs
@@ -1,0 +1,5 @@
+﻿using Tfplugin5;
+
+namespace TerraformPluginDotNet.ResourceProvider;
+
+public record DataSourceRegistration(string ResourceName, Type Type, Schema Schema);

--- a/TerraformPluginDotNet/ResourceProvider/IDataSourceSchemaProvider.cs
+++ b/TerraformPluginDotNet/ResourceProvider/IDataSourceSchemaProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace TerraformPluginDotNet.ResourceProvider;
+
+public interface IDataSourceSchemaProvider
+{
+    IEnumerable<DataSourceRegistration> GetSchemas();
+}

--- a/TerraformPluginDotNet/ResourceProvider/ResourceRegistry.cs
+++ b/TerraformPluginDotNet/ResourceProvider/ResourceRegistry.cs
@@ -6,19 +6,28 @@ namespace TerraformPluginDotNet.ResourceProvider;
 class ResourceRegistry
 {
     public ResourceRegistry(
-        ISchemaBuilder schemaBulder,
+        ISchemaBuilder schemaBuilder,
         IEnumerable<ResourceRegistryRegistration> resourceRegistrations,
-        IEnumerable<DataSourceRegistryRegistration> dataSourceRegistrations)
+        IEnumerable<DataSourceRegistryRegistration> dataSourceRegistrations,
+        IEnumerable<IDataSourceSchemaProvider> dataSourceSchemaProviders)
     {
         foreach (var registration in resourceRegistrations)
         {
-            Schemas.Add(registration.ResourceName, schemaBulder.BuildSchema(registration.Type));
+            Schemas.Add(registration.ResourceName, schemaBuilder.BuildSchema(registration.Type));
             Types.Add(registration.ResourceName, registration.Type);
         }
         foreach (var registration in dataSourceRegistrations)
         {
-            DataSchemas.Add(registration.ResourceName, schemaBulder.BuildSchema(registration.Type));
+            DataSchemas.Add(registration.ResourceName, schemaBuilder.BuildSchema(registration.Type));
             DataTypes.Add(registration.ResourceName, registration.Type);
+        }
+        foreach (var provider in dataSourceSchemaProviders)
+        {
+            foreach (var registration in provider.GetSchemas())
+            {
+                DataSchemas.Add(registration.ResourceName, registration.Schema);
+                DataTypes.Add(registration.ResourceName, registration.Type);
+            }
         }
     }
 

--- a/TerraformPluginDotNet/ResourceProvider/ServiceCollectionResourceRegistryContext.cs
+++ b/TerraformPluginDotNet/ResourceProvider/ServiceCollectionResourceRegistryContext.cs
@@ -18,11 +18,11 @@ class ServiceCollectionResourceRegistryContext : IResourceRegistryContext
         _services.AddSingleton(new ResourceRegistryRegistration(resourceName, typeof(T)));
     }
 
-    public void RegisterDataSource<T>(string resourceName)
+    public void RegisterDataSource<T>(string dataSourceName)
     {
         EnsureValidType<T>();
 
-        _services.AddSingleton(new DataSourceRegistryRegistration(resourceName, typeof(T)));
+        _services.AddSingleton(new DataSourceRegistryRegistration(dataSourceName, typeof(T)));
     }
 
     private static void EnsureValidType<T>()


### PR DESCRIPTION
This PR adds `IDataSourceSchemaProvider` which is an interface that allows plugins to provide custom schemas that are not bound to a specific concrete type. One can output a schema containing objects with certain properties, but use an type that receives those properties in something like `Dictionary<string, Dictionary<string, object>>`. 

I don't know if you want to go this direction with this plugin, but this allows for creating a bunch of specialized schemas, but handle those using a single type.

A use case for this is, for example, create a terraform plugin that reads a certain folder for specific files, parse those files, and output a schemas for each file, containing properties from those files. Those files can then be referenced in the terraform template, and the code suggestions will reflect those exact files and their contents.