### PR TITLE
Make attribute resolution extensible via dependency injection.

### DIFF
--- a/TerraformPluginDotNet.Test/ResourceProvider/ResourceRegistryTest.cs
+++ b/TerraformPluginDotNet.Test/ResourceProvider/ResourceRegistryTest.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using TerraformPluginDotNet.ResourceProvider;
 using TerraformPluginDotNet.Schemas;
+using TerraformPluginDotNet.Schemas.Attributes;
 using TerraformPluginDotNet.Schemas.Types;
 using Tfplugin5;
 
@@ -38,7 +39,7 @@ public class ResourceRegistryTest
     {
         var registration = new ResourceRegistryRegistration("test_resource", typeof(TestResource));
         var dataSourceRegistration = new DataSourceRegistryRegistration("test_data_source", typeof(TestResource));
-        var registry = new ResourceRegistry(new SchemaBuilder(NullLogger<SchemaBuilder>.Instance, new TerraformTypeBuilder()), new[] { registration }, new[] { dataSourceRegistration });
+        var registry = new ResourceRegistry(new SchemaBuilder(NullLogger<SchemaBuilder>.Instance, new TerraformTypeBuilder(), new TerraformAttributeResolver()), new[] { registration }, new[] { dataSourceRegistration });
         return registry;
     }
 }

--- a/TerraformPluginDotNet.Test/Schemas/SchemaBuilderTest.cs
+++ b/TerraformPluginDotNet.Test/Schemas/SchemaBuilderTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using TerraformPluginDotNet.Schemas;
+using TerraformPluginDotNet.Schemas.Attributes;
 using TerraformPluginDotNet.Schemas.Types;
 
 namespace TerraformPluginDotNet.Test.Schemas;
@@ -16,7 +17,8 @@ public class SchemaBuilderTest
     {
         _schemaBuilder = new SchemaBuilder(
             NullLogger<SchemaBuilder>.Instance,
-            new TerraformTypeBuilder());
+            new TerraformTypeBuilder(),
+            new TerraformAttributeResolver());
     }
 
     [Test]

--- a/TerraformPluginDotNet/Schemas/Attributes/ITerraformAttributeResolver.cs
+++ b/TerraformPluginDotNet/Schemas/Attributes/ITerraformAttributeResolver.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+
+namespace TerraformPluginDotNet.Schemas.Attributes;
+
+public interface ITerraformAttributeResolver
+{
+    string GetKey(PropertyInfo property);
+
+    string? GetDescription(PropertyInfo property);
+
+    bool IsRequired(PropertyInfo property);
+
+    bool IsComputed(PropertyInfo property);
+
+    bool? IsOptional(PropertyInfo property);
+}

--- a/TerraformPluginDotNet/Schemas/Attributes/TerraformAttributeResolver.cs
+++ b/TerraformPluginDotNet/Schemas/Attributes/TerraformAttributeResolver.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+using MessagePack;
+using TerraformPluginDotNet.Resources;
+using TerraformPluginDotNet.Schemas.Types;
+
+namespace TerraformPluginDotNet.Schemas.Attributes;
+
+public class TerraformAttributeResolver : ITerraformAttributeResolver
+{
+    public string? GetDescription(PropertyInfo property)
+    {
+        return property.GetCustomAttribute<DescriptionAttribute>()?.Description;
+    }
+
+    public string GetKey(PropertyInfo property)
+    {
+        return property.GetCustomAttribute<KeyAttribute>()?.StringKey ?? throw new InvalidOperationException($"Missing {nameof(KeyAttribute)} on {property.Name} in {property.DeclaringType?.Name}.");
+    }
+
+    public bool IsComputed(PropertyInfo property)
+    {
+        return property.GetCustomAttribute<ComputedAttribute>() is not null;
+    }
+
+    public bool? IsOptional(PropertyInfo property)
+    {
+        return null;
+    }
+
+    public bool IsRequired(PropertyInfo property)
+    {
+        return TerraformTypeBuilder.IsRequiredAttribute(property);
+    }
+}

--- a/TerraformPluginDotNet/ServiceCollectionExtensions.cs
+++ b/TerraformPluginDotNet/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using TerraformPluginDotNet.ProviderConfig;
 using TerraformPluginDotNet.ResourceProvider;
 using TerraformPluginDotNet.Schemas;
+using TerraformPluginDotNet.Schemas.Attributes;
 using TerraformPluginDotNet.Schemas.Types;
 using TerraformPluginDotNet.Serialization;
 
@@ -15,6 +16,7 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddTerraformPluginCore(this IServiceCollection services)
     {
+        services.AddTransient<ITerraformAttributeResolver, TerraformAttributeResolver>();
         services.AddTransient<ITerraformTypeBuilder, TerraformTypeBuilder>();
         services.AddTransient<ISchemaBuilder, SchemaBuilder>();
         services.AddTransient(typeof(ProviderConfigurationHost<>));


### PR DESCRIPTION
Added ITerraformAttributeResolver.cs in order to make attribute resolution extensible via dependency injection.
This Pull Request also makes TerraformTypeBuilder public so that it can be encapsulated by clients.